### PR TITLE
Fixing nscale container list example.

### DIFF
--- a/tutorials/8-deploy-to-aws.md
+++ b/tutorials/8-deploy-to-aws.md
@@ -142,7 +142,7 @@ nscale system compile sudc aws
 ```
 Now let's take a look at the system definition:
 ```bash
-nscale container list sudc
+nscale container list
 ```
 You should see the following containers:
 ```bash


### PR DESCRIPTION
Unless I'm mistaken, `nscale container list <rev>` take a revision argument that matches that start of git revisions.
